### PR TITLE
feat(worker): allow providing config file as an env var

### DIFF
--- a/inbound-event-listener/worker/docker/entrypoint.sh
+++ b/inbound-event-listener/worker/docker/entrypoint.sh
@@ -3,4 +3,11 @@ set -e
 
 echo "Container started"
 
+# Allow for translating a env var into a local config file
+if [[ -n "${CONFIG_FILE_VALUE}" ]]; then
+    echo "Config file provided by env var. Writing to file..."
+    echo "${CONFIG_FILE_VALUE}" > /tmp/config.json
+    export CONFIG_FILE="/tmp/config.json"
+fi
+
 exec "$@"


### PR DESCRIPTION
minor feature to allow for writing the config file if its been provided as an env var
This is mostly to support the current config file and allows us to deploy it using standard env vars